### PR TITLE
Add faker for sample feed posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "@faker-js/faker": "^8.4.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(afterLogin)/AfterLoginPage.style.ts
+++ b/src/app/(afterLogin)/AfterLoginPage.style.ts
@@ -5,4 +5,10 @@ export const Main = styled.div`
   justify-content: center;
   max-width: 1000px;
   margin: 0 auto;
+  padding-top: 20px;
+`;
+
+export const FeedArea = styled.div`
+  flex: 1;
+  overflow-y: auto;
 `;

--- a/src/app/(afterLogin)/AfterLoginPage.tsx
+++ b/src/app/(afterLogin)/AfterLoginPage.tsx
@@ -1,41 +1,33 @@
 import FeedItem from "./_components/feed";
 import { Main } from "./AfterLoginPage.style";
+import { faker } from "@faker-js/faker";
+import { useMemo } from "react";
 
-const dummyData = [
-  {
-    username: 'haebi.dev',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '오늘도 개발하는 하루 🧑‍💻'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  }
-];
+interface Post {
+  username: string;
+  avatarUrl: string;
+  imageUrl: string;
+  description: string;
+}
 
 export default function AfterLoginPage() {
+  const dummyData: Post[] = useMemo(
+    () =>
+      Array.from({ length: 5 }).map(() => ({
+        username: faker.internet.userName(),
+        avatarUrl: faker.image.avatar(),
+        imageUrl: faker.image.urlPicsumPhotos({ width: 600, height: 400 }),
+        description: faker.lorem.sentence(),
+      })),
+    []
+  );
   return (
     <Main>
       {dummyData.map((item, idx) => (
         <FeedItem
           key={idx}
           username={item.username}
+          avatarUrl={item.avatarUrl}
           imageUrl={item.imageUrl}
           description={item.description}
         />

--- a/src/app/(afterLogin)/AfterLoginPage.tsx
+++ b/src/app/(afterLogin)/AfterLoginPage.tsx
@@ -1,5 +1,6 @@
 import FeedItem from "./_components/feed";
-import { Main } from "./AfterLoginPage.style";
+import LeftSide from "./_components/leftSide";
+import { Main, FeedArea } from "./AfterLoginPage.style";
 import { faker } from "@faker-js/faker";
 import { useMemo } from "react";
 
@@ -23,15 +24,18 @@ export default function AfterLoginPage() {
   );
   return (
     <Main>
-      {dummyData.map((item, idx) => (
-        <FeedItem
-          key={idx}
-          username={item.username}
-          avatarUrl={item.avatarUrl}
-          imageUrl={item.imageUrl}
-          description={item.description}
-        />
-      ))}
+      <LeftSide />
+      <FeedArea>
+        {dummyData.map((item, idx) => (
+          <FeedItem
+            key={idx}
+            username={item.username}
+            avatarUrl={item.avatarUrl}
+            imageUrl={item.imageUrl}
+            description={item.description}
+          />
+        ))}
+      </FeedArea>
     </Main>
   );
 }

--- a/src/app/(afterLogin)/_components/feed.style.ts
+++ b/src/app/(afterLogin)/_components/feed.style.ts
@@ -12,6 +12,16 @@ export const FeedHeader = styled.header`
   padding: 12px 16px;
   font-weight: bold;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const Avatar = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
 `;
 
 export const Username = styled.span`

--- a/src/app/(afterLogin)/_components/feed.tsx
+++ b/src/app/(afterLogin)/_components/feed.tsx
@@ -6,19 +6,22 @@ import {
   FeedImage,
   FeedFooter,
   Username,
-  Description
+  Description,
+  Avatar
 } from './feed.style';
 
 interface FeedItemProps {
   username: string;
+  avatarUrl: string;
   imageUrl: string;
   description: string;
 }
 
-export default function FeedItem({ username, imageUrl, description }: FeedItemProps) {
+export default function FeedItem({ username, avatarUrl, imageUrl, description }: FeedItemProps) {
   return (
     <FeedWrapper>
       <FeedHeader>
+        <Avatar src={avatarUrl} alt={username} />
         <Username>{username}</Username>
       </FeedHeader>
       <FeedImage src={imageUrl} alt="post" />

--- a/src/app/(afterLogin)/_components/leftSide.style.ts
+++ b/src/app/(afterLogin)/_components/leftSide.style.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Nav = styled.nav`
+  width: 220px;
+  padding: 24px 16px;
+`;
+
+export const NavList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const NavItem = styled.li`
+  font-size: 16px;
+  cursor: pointer;
+`;
+
+export const Profile = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 24px;
+`;
+
+export const Avatar = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+`;

--- a/src/app/(afterLogin)/_components/leftSide.tsx
+++ b/src/app/(afterLogin)/_components/leftSide.tsx
@@ -1,7 +1,24 @@
+import { faker } from '@faker-js/faker';
+import { Nav, NavList, NavItem, Profile, Avatar } from './leftSide.style';
+
 export default function LeftSide() {
+  const avatar = faker.image.avatar();
   return (
-    <div>
-      <h2>Left Side</h2>
-    </div>
+    <Nav>
+      <NavList>
+        <NavItem>홈</NavItem>
+        <NavItem>검색</NavItem>
+        <NavItem>탐색 탭</NavItem>
+        <NavItem>릴스</NavItem>
+        <NavItem>메시지</NavItem>
+        <NavItem>알림</NavItem>
+        <NavItem>만들기</NavItem>
+      </NavList>
+      <Profile>
+        <Avatar src={avatar} alt="fingerpets96 프로필" />
+        <span>fingerpets96</span>
+      </Profile>
+      <NavItem>프로필</NavItem>
+    </Nav>
   );
 }


### PR DESCRIPTION
## Summary
- generate dummy posts with faker in main page
- show user avatar in feed header
- adjust feed header style to display avatar
- add faker dependency

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687461bdb7708321b96fa0b89c5f707b