### PR TITLE
Improve Instagram-like feed design

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "@faker-js/faker": "^8.4.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(afterLogin)/AfterLoginPage.style.ts
+++ b/src/app/(afterLogin)/AfterLoginPage.style.ts
@@ -2,7 +2,21 @@ import styled from 'styled-components';
 
 export const Main = styled.div`
   display: flex;
-  justify-content: center;
-  max-width: 1000px;
+  max-width: 935px;
   margin: 0 auto;
+`;
+
+export const LeftArea = styled.div`
+  width: 220px;
+  border-right: 1px solid #dbdbdb;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+`;
+
+export const ContentArea = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  height: 100vh;
+  padding: 20px 0;
 `;

--- a/src/app/(afterLogin)/AfterLoginPage.tsx
+++ b/src/app/(afterLogin)/AfterLoginPage.tsx
@@ -1,45 +1,49 @@
 import FeedItem from "./_components/feed";
-import { Main } from "./AfterLoginPage.style";
+import LeftSide from "./_components/leftSide";
+import { Main, LeftArea, ContentArea } from "./AfterLoginPage.style";
+import { faker } from "@faker-js/faker";
+import { useMemo } from "react";
 
-const dummyData = [
-  {
-    username: 'haebi.dev',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '오늘도 개발하는 하루 🧑‍💻'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  },
-  {
-    username: 'daily.cat',
-    imageUrl: 'https://placehold.co/600x400',
-    description: '냥냥펀치 발사!'
-  }
-];
+interface Post {
+  username: string;
+  avatarUrl: string;
+  imageUrl: string;
+  description: string;
+  likeCount: number;
+  commentCount: number;
+}
 
 export default function AfterLoginPage() {
+  const dummyData: Post[] = useMemo(
+    () =>
+      Array.from({ length: 5 }).map(() => ({
+        username: faker.internet.userName(),
+        avatarUrl: faker.image.avatar(),
+        imageUrl: faker.image.urlPicsumPhotos({ width: 600, height: 400 }),
+        description: faker.lorem.sentence(),
+        likeCount: faker.number.int({ min: 1, max: 5000 }),
+        commentCount: faker.number.int({ min: 1, max: 200 }),
+      })),
+    []
+  );
   return (
     <Main>
-      {dummyData.map((item, idx) => (
-        <FeedItem
-          key={idx}
-          username={item.username}
-          imageUrl={item.imageUrl}
-          description={item.description}
-        />
-      ))}
+      <LeftArea>
+        <LeftSide />
+      </LeftArea>
+      <ContentArea>
+        {dummyData.map((item, idx) => (
+          <FeedItem
+            key={idx}
+            username={item.username}
+            avatarUrl={item.avatarUrl}
+            imageUrl={item.imageUrl}
+            description={item.description}
+            likeCount={item.likeCount}
+            commentCount={item.commentCount}
+          />
+        ))}
+      </ContentArea>
     </Main>
   );
 }

--- a/src/app/(afterLogin)/[username]/page.tsx
+++ b/src/app/(afterLogin)/[username]/page.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  params: { username: string };
+}
+
+export default function UserPage({ params }: Props) {
+  return <div>{params.username}님의 프로필</div>;
+}

--- a/src/app/(afterLogin)/[username]/saved/page.tsx
+++ b/src/app/(afterLogin)/[username]/saved/page.tsx
@@ -1,0 +1,3 @@
+export default function SavedPage() {
+  return <div>저장됨 페이지</div>;
+}

--- a/src/app/(afterLogin)/[username]/tagged/page.tsx
+++ b/src/app/(afterLogin)/[username]/tagged/page.tsx
@@ -1,0 +1,3 @@
+export default function TaggedPage() {
+  return <div>태그됨 페이지</div>;
+}

--- a/src/app/(afterLogin)/_components/feed.style.ts
+++ b/src/app/(afterLogin)/_components/feed.style.ts
@@ -4,7 +4,7 @@ export const FeedWrapper = styled.article`
   border: 1px solid #dbdbdb;
   border-radius: 8px;
   margin: 20px auto;
-  max-width: 500px;
+  max-width: 470px;
   background-color: #fff;
 `;
 
@@ -12,6 +12,17 @@ export const FeedHeader = styled.header`
   padding: 12px 16px;
   font-weight: bold;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: space-between;
+`;
+
+export const Avatar = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
 `;
 
 export const Username = styled.span`
@@ -20,7 +31,6 @@ export const Username = styled.span`
 
 export const FeedImage = styled.img`
   width: 100%;
-  max-width: 300px;
   display: block;
 `;
 
@@ -31,4 +41,31 @@ export const FeedFooter = styled.footer`
 export const Description = styled.p`
   font-size: 14px;
   color: #262626;
+`;
+
+export const FeedActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 16px;
+  svg {
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+  }
+`;
+
+export const ActionsLeft = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export const Likes = styled.p`
+  font-weight: bold;
+  padding: 0 16px;
+`;
+
+export const CommentCount = styled.p`
+  padding: 0 16px;
+  color: #737373;
+  font-size: 14px;
 `;

--- a/src/app/(afterLogin)/_components/feed.tsx
+++ b/src/app/(afterLogin)/_components/feed.tsx
@@ -6,24 +6,56 @@ import {
   FeedImage,
   FeedFooter,
   Username,
-  Description
+  Description,
+  Avatar,
+  FeedActions,
+  ActionsLeft,
+  Likes,
+  CommentCount,
 } from './feed.style';
+import { FiHeart, FiMessageCircle, FiSend, FiBookmark, FiMoreHorizontal } from 'react-icons/fi';
 
 interface FeedItemProps {
   username: string;
+  avatarUrl: string;
   imageUrl: string;
   description: string;
+  likeCount: number;
+  commentCount: number;
 }
 
-export default function FeedItem({ username, imageUrl, description }: FeedItemProps) {
+export default function FeedItem({
+  username,
+  avatarUrl,
+  imageUrl,
+  description,
+  likeCount,
+  commentCount,
+}: FeedItemProps) {
   return (
     <FeedWrapper>
       <FeedHeader>
-        <Username>{username}</Username>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Avatar src={avatarUrl} alt={username} />
+          <Username>{username}</Username>
+        </div>
+        <FiMoreHorizontal />
       </FeedHeader>
       <FeedImage src={imageUrl} alt="post" />
+      <FeedActions>
+        <ActionsLeft>
+          <FiHeart />
+          <FiMessageCircle />
+          <FiSend />
+        </ActionsLeft>
+        <FiBookmark />
+      </FeedActions>
+      <Likes>{`좋아요 ${likeCount}개`}</Likes>
       <FeedFooter>
-        <Description>{description}</Description>
+        <Description>
+          <Username>{username}</Username> {description}
+        </Description>
+        <CommentCount>{`댓글 ${commentCount}개 모두 보기`}</CommentCount>
       </FeedFooter>
     </FeedWrapper>
   );

--- a/src/app/(afterLogin)/_components/leftSide.style.ts
+++ b/src/app/(afterLogin)/_components/leftSide.style.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import Link from 'next/link';
+
+export const NavWrap = styled.nav`
+  padding: 20px 12px;
+`;
+
+export const Logo = styled.h1`
+  font-family: 'Segoe UI', sans-serif;
+  font-size: 24px;
+  margin-bottom: 24px;
+`;
+
+export const NavList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const NavItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+export const NavLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+export const Avatar = styled.img`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+`;

--- a/src/app/(afterLogin)/_components/leftSide.tsx
+++ b/src/app/(afterLogin)/_components/leftSide.tsx
@@ -1,7 +1,57 @@
+'use client';
+
+import { NavWrap, NavList, NavItem, NavLink, Avatar, Logo } from './leftSide.style';
+import { faker } from '@faker-js/faker';
+import { FiHome, FiSearch, FiCompass, FiFilm, FiSend, FiHeart, FiPlusSquare } from 'react-icons/fi';
+
 export default function LeftSide() {
+  const avatar = faker.image.avatar();
   return (
-    <div>
-      <h2>Left Side</h2>
-    </div>
+    <NavWrap>
+      <Logo>Instagram</Logo>
+      <NavList>
+        <NavItem>
+          <NavLink href="/">
+            <FiHome /> 홈
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/search">
+            <FiSearch /> 검색
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/explore">
+            <FiCompass /> 탐색 탭
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/reels">
+            <FiFilm /> 릴스
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/direct/inbox">
+            <FiSend /> 메시지
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/notifications">
+            <FiHeart /> 알림
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/create">
+            <FiPlusSquare /> 만들기
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink href="/fingerpets96">
+            <Avatar src={avatar} alt="fingerpets96님의 프로필 사진" />
+            프로필
+          </NavLink>
+        </NavItem>
+      </NavList>
+    </NavWrap>
   );
 }

--- a/src/app/(afterLogin)/create/page.tsx
+++ b/src/app/(afterLogin)/create/page.tsx
@@ -1,0 +1,3 @@
+export default function CreatePage() {
+  return <div>만들기 페이지</div>;
+}

--- a/src/app/(afterLogin)/direct/[chatId]/page.tsx
+++ b/src/app/(afterLogin)/direct/[chatId]/page.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  params: { chatId: string };
+}
+
+export default function ChatPage({ params }: Props) {
+  return <div>{params.chatId}번 채팅</div>;
+}

--- a/src/app/(afterLogin)/direct/inbox/page.tsx
+++ b/src/app/(afterLogin)/direct/inbox/page.tsx
@@ -1,0 +1,3 @@
+export default function InboxPage() {
+  return <div>메시지 페이지</div>;
+}

--- a/src/app/(afterLogin)/explore/page.tsx
+++ b/src/app/(afterLogin)/explore/page.tsx
@@ -1,0 +1,3 @@
+export default function ExplorePage() {
+  return <div>탐색 탭 페이지</div>;
+}

--- a/src/app/(afterLogin)/notifications/page.tsx
+++ b/src/app/(afterLogin)/notifications/page.tsx
@@ -1,0 +1,3 @@
+export default function NotificationsPage() {
+  return <div>알림 페이지</div>;
+}

--- a/src/app/(afterLogin)/reels/page.tsx
+++ b/src/app/(afterLogin)/reels/page.tsx
@@ -1,0 +1,3 @@
+export default function ReelsPage() {
+  return <div>릴스 페이지</div>;
+}

--- a/src/app/(afterLogin)/search/page.tsx
+++ b/src/app/(afterLogin)/search/page.tsx
@@ -1,0 +1,3 @@
+export default function SearchPage() {
+  return <div>검색 페이지</div>;
+}


### PR DESCRIPTION
## Summary
- refine feed appearance with icons and counts
- add brand header on left navigation
- ensure scrollable content area with padding
- randomize likes and comments in dummy data
- link left menu items to new placeholder pages
- add placeholder pages for search, explore, reels, inbox and others

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687461bdb7708321b96fa0b89c5f707b