### PR TITLE
Add sidebar links and placeholder pages

### DIFF
--- a/src/app/(afterLogin)/[username]/page.tsx
+++ b/src/app/(afterLogin)/[username]/page.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  params: { username: string };
+}
+
+export default function ProfilePage({ params }: Props) {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>{`${params.username} 프로필 페이지 (준비 중)`}</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/_components/leftSide.style.ts
+++ b/src/app/(afterLogin)/_components/leftSide.style.ts
@@ -22,16 +22,19 @@ export const NavList = styled.ul`
 `;
 
 export const NavItem = styled.li`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
+  a {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    color: inherit;
 
-  svg {
-    width: 24px;
-    height: 24px;
+    svg {
+      width: 24px;
+      height: 24px;
+    }
   }
 
   &:last-child {

--- a/src/app/(afterLogin)/_components/leftSide.tsx
+++ b/src/app/(afterLogin)/_components/leftSide.tsx
@@ -2,23 +2,63 @@
 
 import { NavWrap, NavList, NavItem, Avatar, Logo } from './leftSide.style';
 import { faker } from '@faker-js/faker';
-import { FiHome, FiSearch, FiCompass, FiFilm, FiSend, FiHeart, FiPlusSquare, FiUser } from 'react-icons/fi';
+import Link from 'next/link';
+import {
+  FiHome,
+  FiSearch,
+  FiCompass,
+  FiFilm,
+  FiSend,
+  FiHeart,
+  FiPlusSquare,
+  FiUser,
+} from 'react-icons/fi';
 
 export default function LeftSide() {
   return (
     <NavWrap>
       <Logo>Instagram</Logo>
       <NavList>
-        <NavItem><FiHome /> 홈</NavItem>
-        <NavItem><FiSearch /> 검색</NavItem>
-        <NavItem><FiCompass /> 탐색 탭</NavItem>
-        <NavItem><FiFilm /> 릴스</NavItem>
-        <NavItem><FiSend /> 메시지</NavItem>
-        <NavItem><FiHeart /> 알림</NavItem>
-        <NavItem><FiPlusSquare /> 만들기</NavItem>
         <NavItem>
-          <Avatar src={faker.image.avatar()} alt="fingerpets96님의 프로필 사진" />
-          프로필
+          <Link href="/">
+            <FiHome /> <span>홈</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/search">
+            <FiSearch /> <span>검색</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/explore">
+            <FiCompass /> <span>탐색 탭</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/reels">
+            <FiFilm /> <span>릴스</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/direct/inbox">
+            <FiSend /> <span>메시지</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/notifications">
+            <FiHeart /> <span>알림</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/create">
+            <FiPlusSquare /> <span>만들기</span>
+          </Link>
+        </NavItem>
+        <NavItem>
+          <Link href="/my_profile">
+            <Avatar src={faker.image.avatar()} alt="fingerpets96님의 프로필 사진" />
+            <span>프로필</span>
+          </Link>
         </NavItem>
       </NavList>
     </NavWrap>

--- a/src/app/(afterLogin)/create/page.tsx
+++ b/src/app/(afterLogin)/create/page.tsx
@@ -1,0 +1,7 @@
+export default function CreatePage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>만들기 페이지 (준비 중)</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/direct/[chatId]/page.tsx
+++ b/src/app/(afterLogin)/direct/[chatId]/page.tsx
@@ -1,0 +1,11 @@
+interface Props {
+  params: { chatId: string };
+}
+
+export default function ChatPage({ params }: Props) {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>{`채팅 ${params.chatId} (준비 중)`}</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/direct/inbox/page.tsx
+++ b/src/app/(afterLogin)/direct/inbox/page.tsx
@@ -1,0 +1,7 @@
+export default function InboxPage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>메시지 인박스 (준비 중)</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/explore/page.tsx
+++ b/src/app/(afterLogin)/explore/page.tsx
@@ -1,0 +1,7 @@
+export default function ExplorePage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>탐색 탭 페이지 (준비 중)</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/notifications/page.tsx
+++ b/src/app/(afterLogin)/notifications/page.tsx
@@ -1,0 +1,7 @@
+export default function NotificationsPage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>알림 페이지 (준비 중)</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/reels/page.tsx
+++ b/src/app/(afterLogin)/reels/page.tsx
@@ -1,0 +1,7 @@
+export default function ReelsPage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>릴스 페이지 (준비 중)</h2>
+    </div>
+  );
+}

--- a/src/app/(afterLogin)/search/page.tsx
+++ b/src/app/(afterLogin)/search/page.tsx
@@ -1,0 +1,7 @@
+export default function SearchPage() {
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>검색 페이지 (준비 중)</h2>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Link` navigation to the sidebar
- add minimal pages for search, explore, reels, direct messages and profile
- add new placeholder pages for notifications and create

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874921b19688321958f807bbe56da89