### PR TITLE
Use MirageJS with React Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "styled-components": "^6.1.19",
-    "@faker-js/faker": "^8.4.1"
+    "@faker-js/faker": "^8.4.1",
+    "@tanstack/react-query": "^5.35.0",
+    "miragejs": "^0.1.45"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",

--- a/src/app/(afterLogin)/AfterLoginPage.tsx
+++ b/src/app/(afterLogin)/AfterLoginPage.tsx
@@ -1,10 +1,10 @@
 import FeedItem from "./_components/feed";
 import LeftSide from "./_components/leftSide";
 import { Main, LeftArea, ContentArea } from "./AfterLoginPage.style";
-import { faker } from "@faker-js/faker";
-import { useMemo } from "react";
+import { useQuery } from '@tanstack/react-query';
 
 interface Post {
+  id: string;
   username: string;
   avatarUrl: string;
   imageUrl: string;
@@ -13,26 +13,24 @@ interface Post {
   commentCount: number;
 }
 
+async function fetchPosts(): Promise<Post[]> {
+  const res = await fetch('/api/posts');
+  const data = await res.json();
+  return (data.posts ?? []) as Post[];
+}
+
 export default function AfterLoginPage() {
-  const dummyData: Post[] = useMemo(
-    () =>
-      Array.from({ length: 5 }).map(() => ({
-        username: faker.internet.userName(),
-        avatarUrl: faker.image.avatar(),
-        imageUrl: faker.image.urlPicsumPhotos({ width: 600, height: 400 }),
-        description: faker.lorem.sentence(),
-        likeCount: faker.number.int({ min: 1, max: 5000 }),
-        commentCount: faker.number.int({ min: 1, max: 200 }),
-      })),
-    []
-  );
+  const { data: posts = [] } = useQuery<Post[]>({
+    queryKey: ['posts'],
+    queryFn: fetchPosts,
+  });
   return (
     <Main>
       <LeftArea>
         <LeftSide />
       </LeftArea>
       <ContentArea>
-        {dummyData.map((item, idx) => (
+        {posts.map((item, idx) => (
           <FeedItem
             key={idx}
             username={item.username}

--- a/src/app/_lib/react-query-provider.tsx
+++ b/src/app/_lib/react-query-provider.tsx
@@ -1,0 +1,8 @@
+'use client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from 'react';
+
+export default function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,16 +4,25 @@ import GlobalStyle from '@/app/_styles/global.style';
 import FontsStyle from '@/app/_styles/fonts.style';
 import { ThemeProvider } from "styled-components";
 import { theme } from "@/app/_styles/theme";
+import ReactQueryProvider from './_lib/react-query-provider';
+import { useEffect } from 'react';
+import { makeServer } from '@/mirage/server';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    makeServer();
+  }, []);
+
   return (
     <html lang="ko">
       <body>
         <StyledComponentsRegistry>
           <ThemeProvider theme={theme}>
-            <GlobalStyle />
-            <FontsStyle />
-            {children}
+            <ReactQueryProvider>
+              <GlobalStyle />
+              <FontsStyle />
+              {children}
+            </ReactQueryProvider>
           </ThemeProvider>
         </StyledComponentsRegistry>
       </body>

--- a/src/mirage/server.ts
+++ b/src/mirage/server.ts
@@ -1,0 +1,43 @@
+import { createServer, Factory, Model } from 'miragejs';
+import { faker } from '@faker-js/faker';
+
+export function makeServer() {
+  return createServer({
+    models: {
+      post: Model,
+    },
+    factories: {
+      post: Factory.extend({
+        username() {
+          return faker.internet.userName();
+        },
+        avatarUrl() {
+          return faker.image.avatar();
+        },
+        imageUrl() {
+          return faker.image.urlPicsumPhotos({ width: 600, height: 400 });
+        },
+        description() {
+          return faker.lorem.sentence();
+        },
+        likeCount() {
+          return faker.number.int({ min: 1, max: 5000 });
+        },
+        commentCount() {
+          return faker.number.int({ min: 1, max: 200 });
+        },
+      }),
+    },
+    seeds(server) {
+      server.createList('post', 5);
+    },
+    routes() {
+      this.namespace = 'api';
+      this.timing = 750;
+      this.get('/posts', (schema) => {
+        // @ts-ignore
+        return schema.all('post');
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- bootstrap MirageJS server with dummy post data
- wrap app with React Query provider
- fetch posts with React Query on the main page
- add required dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749b38a018832189d1be791da84fef