### PR TITLE
Fix login API url and cleanup signup

### DIFF
--- a/src/app/_lib/signup.ts
+++ b/src/app/_lib/signup.ts
@@ -18,7 +18,8 @@ export default async (prevState: { message: string | null }, formData: FormData)
   }
   let shouldRedirect = false;
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/users`, {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
+    const response = await fetch(`${baseUrl}/api/users`, {
       method: 'post',
       body: formData,
       credentials: 'include',
@@ -30,7 +31,7 @@ export default async (prevState: { message: string | null }, formData: FormData)
     console.log(await response.json())
     shouldRedirect = true;
     await signIn("credentials", {
-      username: formData.get('id'),
+      email: formData.get('id'),
       password: formData.get('password'),
       redirect: false,
     })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -17,7 +17,8 @@ const handler = NextAuth({
         console.log("로그인데이터:", credentials);
 
         // 1. 외부 API로 로그인 요청
-        const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/providers`, {
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
+        const response = await fetch(`${baseUrl}/api/auth/callback/credentials`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- fix login endpoint URL
- normalize base URL handling
- fix sign up to pass `email` and support missing env var

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cd4467fc8321b7e76634ca4353f0