### PR TITLE
Fix login for latest authjs

### DIFF
--- a/src/app/(beforeLogin)/_components/LoginForm.tsx
+++ b/src/app/(beforeLogin)/_components/LoginForm.tsx
@@ -23,7 +23,7 @@ export default function LoginForm() {
     
     try {
       const result = await signIn("credentials", {
-        username: id.value,
+        email: id.value,
         password: password.value,
         redirect: false,
       })

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -12,11 +12,12 @@ export const {
   providers: [
     CredentialsProvider({
       async authorize(credentials) {
-        const authResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/login`, {
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "";
+        const authResponse = await fetch(`${baseUrl}/api/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            id: credentials.username,
+            email: credentials.email,
             password: credentials.password,
           }),
         });


### PR DESCRIPTION
## Summary
- update CredentialsProvider to use `email` and handle missing base url
- use email field when signing in

## Testing
- `npm install` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_6875d02d911483219ec78ca11502b071