### PR TITLE
Move login routes into groups

### DIFF
--- a/src/app/(afterLogin)/page.tsx
+++ b/src/app/(afterLogin)/page.tsx
@@ -1,0 +1,5 @@
+import AfterLoginPage from './AfterLoginPage';
+
+export default function Page() {
+  return <AfterLoginPage />;
+}

--- a/src/app/(beforeLogin)/login/page.tsx
+++ b/src/app/(beforeLogin)/login/page.tsx
@@ -1,0 +1,5 @@
+import BeforeLoginPage from '../BeforeLoginPage';
+
+export default function LoginPage() {
+  return <BeforeLoginPage />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,22 @@
 "use client";
 import { useSession } from "next-auth/react";
-import BeforeLoginPage from './(beforeLogin)/BeforeLoginPage';
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { Loading, LoadingImage } from "./page.style";
 import Image from "next/image";
-import AfterLoginPage from "./(afterLogin)/AfterLoginPage";
 
 export default function Page() {
   const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "loading") return;
+    if (session) {
+      router.replace("/");
+    } else {
+      router.replace("/login");
+    }
+  }, [session, status, router]);
 
   if (status === "loading") {
     return (
@@ -18,9 +28,6 @@ export default function Page() {
     );
   }
 
-  if (session) {
-    return <AfterLoginPage />;
-  }
-
-  return <BeforeLoginPage />;
+  // Redirecting
+  return null;
 }


### PR DESCRIPTION
## Summary
- add `(afterLogin)/page.tsx` to render the existing AfterLoginPage under the logged‑in layout
- expose the login screen at `/login`
- redirect `/` to the appropriate page based on session state

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ae9a2d39c8321bbfd1574f3816f94