### PR TITLE
Implement server-side redirect for root page

### DIFF
--- a/src/app/page.client.tsx
+++ b/src/app/page.client.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useSession } from "next-auth/react";
+import BeforeLoginPage from './(beforeLogin)/BeforeLoginPage';
+import { Loading, LoadingImage } from "./page.style";
+import Image from "next/image";
+import AfterLoginPage from "./(afterLogin)/AfterLoginPage";
+
+export default function Page() {
+  const { data: session, status } = useSession();
+
+  if (status === "loading") {
+    return (
+      <Loading>
+        <LoadingImage>
+          <Image src="/images/img_loading.png" alt="로딩중..." fill />
+        </LoadingImage>
+      </Loading>
+    );
+  }
+
+  if (session) {
+    return <AfterLoginPage />;
+  }
+
+  return <BeforeLoginPage />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,13 @@
-"use client";
-import { useSession } from "next-auth/react";
-import BeforeLoginPage from './(beforeLogin)/BeforeLoginPage';
-import { Loading, LoadingImage } from "./page.style";
-import Image from "next/image";
-import AfterLoginPage from "./(afterLogin)/AfterLoginPage";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/auth";
 
-export default function Page() {
-  const { data: session, status } = useSession();
-
-  if (status === "loading") {
-    return (
-      <Loading>
-        <LoadingImage>
-          <Image src="/images/img_loading.png" alt="로딩중..." fill />
-        </LoadingImage>
-      </Loading>
-    );
-  }
+export default async function Page() {
+  const session = await getServerSession(authOptions);
 
   if (session) {
-    return <AfterLoginPage />;
+    redirect("/(afterLogin)");
+  } else {
+    redirect("/(beforeLogin)/login");
   }
-
-  return <BeforeLoginPage />;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,12 +1,8 @@
-import NextAuth from "next-auth"
+import NextAuth, { type NextAuthConfig } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { faker } from '@faker-js/faker';
 
-export const {
-  handlers: { GET, POST },
-  auth,
-  signIn,
-} = NextAuth({
+export const authOptions: NextAuthConfig = {
   debug: process.env.NODE_ENV === 'development',
   trustHost: true,
   secret: process.env.AUTH_SECRET,
@@ -65,7 +61,7 @@ export const {
     }),
   ],
   pages: {
-    signIn: '/',
+    signIn: '/login',
   },
   callbacks: {
     async signIn({ user, account, profile, email, credentials }) {
@@ -81,4 +77,10 @@ export const {
       return token;
     }
   }
-});
+};
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+} = NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- rename client Home component to `page.client.tsx`
- add new server component at `src/app/page.tsx` that redirects based on session
- export `authOptions` from `auth.ts` and update the NextAuth `signIn` page to `/login`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_688b1a64ff4083219af9b92f78719c61)